### PR TITLE
Add support for the 'X-ORDERED' LDAP extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ansible Changes By Release
 * nxos_portchannel module is deprecated in Ansible 2.5. Use nxos_linkagg module instead.
 * nxos_switchport module is deprecated in Ansible 2.5. Use nxos_l2_interface module instead.
 * ec2_ami_find has been deprecated, use ec2_ami_facts.
+* ldap_attr has been deprecated, use ldap_attrs.
 
 See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) for more information
 
@@ -209,6 +210,7 @@ See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) f
 
 #### Net Tools
   * ip_netns
+  - ldap_attrs
 
 #### Network
 - aci

--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -37,7 +37,10 @@ notes:
     possible to see spurious changes when target and actual values are
     semantically identical but lexically distinct.
 version_added: '2.3'
-deprecated: Deprecated in 2.5. Use M(ldap_attrs) instead.
+deprecated:
+  removed_in: "2.9"
+  why: The current "ldap_attr" module does not support ldap attribute insertations or deletions with objectClass dependencies..
+  alternative: Use M(ldap_attrs) instead.
 author:
   - Jiri Tyr (@jtyr)
 requirements:

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -89,6 +89,14 @@ options:
     description:
       - The attribute(s) and value(s) to add or remove. The complex argument format is required in order to pass
         a list of strings (see examples).
+  ordered:
+￼   required: false
+￼   choices: ['yes', 'no']
+￼   default: 'no'
+￼   description:
+￼     - If C(yes), prepend list values with X-ORDERED index numbers in all
+￼       attributes specified in the current task. This is useful mostly with
+￼       I(olcAccess) attribute to easily manage LDAP Access Control Lists.
   validate_certs:
     required: false
     choices: ['yes', 'no']
@@ -123,6 +131,25 @@ EXAMPLES = """
             {1}to dn.base="dc=example,dc=com"
             by dn="cn=admin,dc=example,dc=com" write
             by * read
+    state: exact
+
+# An alternative approach with automatic X-ORDERED numbering
+- name: Set up the ACL
+  ldap_attrs:
+    dn: olcDatabase={1}hdb,cn=config
+    attributes:
+        olcAccess:
+          - >-
+            to attrs=userPassword,shadowLastChange
+            by self write
+            by anonymous auth
+            by dn="cn=admin,dc=example,dc=com" write
+            by * none'
+          - >-
+            to dn.base="dc=example,dc=com"
+            by dn="cn=admin,dc=example,dc=com" write
+            by * read
+    ordered: yes
     state: exact
 
 - name: Declare some indexes
@@ -178,6 +205,7 @@ modlist:
 """
 
 import traceback
+import re
 
 try:
     import ldap
@@ -203,9 +231,20 @@ class LdapAttr(object):
         self.state = self.module.params['state']
         self.verify_cert = self.module.params['validate_certs']
         self.attrs = self.module.params['attributes']
+        self.ordered = self.module.params['ordered']
 
         # Establish connection
         self.connection = self._connect_to_ldap()
+
+    def _order_values(self, values):
+￼       """ Preprend X-ORDERED index numbers to attribute's values. """
+￼       ordered_values = []
+
+￼       if isinstance(values, list):
+￼           for index, value in enumerate(values):
+￼               cleaned_value = re.sub(r'^\{\d+\}', '', value)
+￼               ordered_values.append('{' + str(index) + '}' + cleaned_value)
+￼       return ordered_values
 
     def _normalize_values(self, values):
         """ Normalize attribute's values. """
@@ -213,6 +252,11 @@ class LdapAttr(object):
 
         if isinstance(values, list):
             norm_values = map(str, values)
+            if self.ordered:
+￼               norm_values = self._order_values(list(map(str, values)))
+￼           else:
+￼               norm_values = list(map(str, values))
+
         elif values != "":
             norm_values = [str(values)]
 
@@ -313,6 +357,7 @@ def main():
                 default='present',
                 choices=['present', 'absent', 'exact']),
             'attributes': dict(required=True, type='dict'),
+            'ordered': dict(default=False, type='bool'),
             'validate_certs': dict(default=True, type='bool'),
         },
         supports_check_mode=True,


### PR DESCRIPTION
This patch adds support for the 'X-ORDERED' LDAP extension, primarly
used by the OpenLDAP project for its configuration stored in the
'cn=config' LDAP database.

This implementation is currently used in the [DebOps](https://github.com/debops/debops/) project to implement support for [OpenLDAP ACL configuration](https://docs.debops.org/en/master/ansible/roles/debops.slapd/defaults.html#envvar-slapd__acl_tasks). I hope that it could be merged into the `ldap_attrs` module to be available in the Ansible core.